### PR TITLE
Release 1.6

### DIFF
--- a/gitops/components/atlantis/application.yaml
+++ b/gitops/components/atlantis/application.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: 'https://runatlantis.github.io/helm-charts'
     chart: atlantis
-    targetRevision: 3.12.11
+    targetRevision: 3.15.0
     helm:
       parameters:
         - name: ingress.host

--- a/gitops/components/chartmuseum/application.yaml
+++ b/gitops/components/chartmuseum/application.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: 'https://chartmuseum.github.io/charts'
-    targetRevision: 3.1.0
+    targetRevision: 3.4.0
     helm:
       values: |-
         env:

--- a/gitops/components/gitlab-runner/application.yaml
+++ b/gitops/components/gitlab-runner/application.yaml
@@ -14,7 +14,7 @@ spec:
   project: default
   source:
     repoURL: 'https://charts.gitlab.io'
-    targetRevision: 0.29.0
+    targetRevision: 0.36.0
     helm:
       parameters:
         - name: rbac.create

--- a/gitops/registry/cert-manager.yaml
+++ b/gitops/registry/cert-manager.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://charts.jetstack.io/
     chart: cert-manager
-    targetRevision: 1.3.1
+    targetRevision: 1.6.1
     helm:
       values: |-
         installCRDs: true

--- a/gitops/registry/external-dns.yaml
+++ b/gitops/registry/external-dns.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: external-dns
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 4.0.0
+    targetRevision: 6.0.2
     helm:
       releaseName: external-dns
       values: |

--- a/gitops/registry/external-secrets.yaml
+++ b/gitops/registry/external-secrets.yaml
@@ -11,7 +11,7 @@ spec:
   project: default
   source:
     repoURL: 'https://external-secrets.github.io/kubernetes-external-secrets'
-    targetRevision: 6.4.0
+    targetRevision: 8.5.0
     helm:
       values: |-
         env:

--- a/gitops/registry/vault.yaml
+++ b/gitops/registry/vault.yaml
@@ -14,7 +14,7 @@ spec:
   project: default
   source:
     repoURL: 'https://helm.releases.hashicorp.com'
-    targetRevision: 0.14.0
+    targetRevision: 0.18.0
     helm:
       parameters:
         - name: server.route.host
@@ -25,7 +25,7 @@ spec:
         server:
           image:
             repository: "vault"
-            tag: "1.8.1"
+            tag: "1.9.2"
           affinity: ""
           ha:
             enabled: true


### PR DESCRIPTION
upgrade cert-manager to 1.6.1
upgrade atlantis to 3.15.0
upgrade chartmuseum to 3.4.0
upgrade external-dns to 6.0.2
upgrade external-secrets to 8.5.0
upgrade gitlab-runner to 0.36.0
upgrade vault to 1.9.2 / chart 0.18.0